### PR TITLE
update ze_maontain_escape

### DIFF
--- a/2001/ze_maontain_escape/knife_stripper.js
+++ b/2001/ze_maontain_escape/knife_stripper.js
@@ -1,0 +1,12 @@
+import { Instance, CSGearSlot } from 'cs_script/point_script';
+
+Instance.OnScriptInput("strip", ({ activator }) => {
+    if (!activator)
+        return;
+
+    const weapon = activator.FindWeaponBySlot(CSGearSlot.KNIFE);
+    if (!weapon)
+        return;
+
+    activator.DestroyWeapon(weapon);
+});


### PR DESCRIPTION
新增knife_stripper脚本, 以方便在玩家拾取匕首时删除其近战武器.